### PR TITLE
Migrate from Laravel Mix to Vite

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY package.json package-lock.json webpack.mix.js /app/
 COPY resources/ /app/resources/
 
 WORKDIR /app
-RUN npm ci && npm run prod
+RUN npm ci && npm run build
 
 # ===================================== #
 FROM alpine:latest as deploy

--- a/package.json
+++ b/package.json
@@ -16,14 +16,14 @@
         "@types/select2": "^4.0.57",
         "axios": "^1.2.1",
         "bootstrap-icons": "^1.10.5",
-        "laravel-vite-plugin": "^0.6.0",
+        "laravel-vite-plugin": "^0.7.8",
         "lodash": "^4.17.19",
         "postcss": "^8.1.14",
         "resolve-url-loader": "^5.0.0",
         "sass": "^1.64.2",
         "semantic-release": "^21.0.7",
         "typescript": "^5.1.6",
-        "vite": "^3.0.2",
+        "vite": "^4.4.8",
         "vite-plugin-checker": "^0.6.1"
     },
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,14 +16,14 @@
         "@types/select2": "^4.0.57",
         "axios": "^1.2.1",
         "bootstrap-icons": "^1.10.5",
-        "laravel-vite-plugin": "^0.7.8",
+        "laravel-vite-plugin": "^0.6.0",
         "lodash": "^4.17.19",
         "postcss": "^8.1.14",
         "resolve-url-loader": "^5.0.0",
         "sass": "^1.64.2",
         "semantic-release": "^21.0.7",
         "typescript": "^5.1.6",
-        "vite": "^4.4.8",
+        "vite": "^3.0.2",
         "vite-plugin-checker": "^0.6.1"
     },
     "dependencies": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,40 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
-    bootstrap="vendor/autoload.php" colors="true">
-    <testsuites>
-        <testsuite name="Unit">
-            <directory suffix="Test.php">./tests/Unit</directory>
-        </testsuite>
-        <testsuite name="Feature">
-            <directory suffix="Test.php">./tests/Feature</directory>
-        </testsuite>
-    </testsuites>
-    <coverage>
-        <include>
-            <directory suffix=".php">./app/Exceptions</directory>
-            <directory suffix=".php">./app/Gates</directory>
-            <directory suffix=".php">./app/Helpers</directory>
-            <directory suffix=".php">./app/Http/Controllers</directory>
-            <directory suffix=".php">./app/Http/Requests</directory>
-            <directory suffix=".php">./app/Imports</directory>
-            <directory suffix=".php">./app/ModelFilters</directory>
-            <directory suffix=".php">./app/Models</directory>
-            <directory suffix=".php">./app/Notifications</directory>
-            <directory suffix=".php">./app/Observers</directory>
-            <directory suffix=".php">./app/Services</directory>
-        </include>
-    </coverage>
-    <php>
-        <env name="APP_ENV" value="testing"/>
-        <env name="APP_KEY" value="base64:spsVoiyikpM+oNpeEI6VWZUIZqoCQFEH+DoxEYCiUew="/>
-        <env name="BCRYPT_ROUNDS" value="4"/>
-        <env name="CACHE_DRIVER" value="array"/>
-        <env name="DB_CONNECTION" value="sqlite"/>
-        <env name="DB_DATABASE" value=":memory:"/>
-        <env name="MAIL_MAILER" value="array"/>
-        <env name="QUEUE_CONNECTION" value="sync"/>
-        <env name="SESSION_DRIVER" value="array"/>
-        <env name="TELESCOPE_ENABLED" value="false"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true">
+  <testsuites>
+    <testsuite name="Unit">
+      <directory suffix="Test.php">./tests/Unit</directory>
+    </testsuite>
+    <testsuite name="Feature">
+      <directory suffix="Test.php">./tests/Feature</directory>
+    </testsuite>
+  </testsuites>
+  <coverage/>
+  <php>
+    <env name="APP_ENV" value="testing"/>
+    <env name="APP_KEY" value="base64:spsVoiyikpM+oNpeEI6VWZUIZqoCQFEH+DoxEYCiUew="/>
+    <env name="BCRYPT_ROUNDS" value="4"/>
+    <env name="CACHE_DRIVER" value="array"/>
+    <env name="DB_CONNECTION" value="sqlite"/>
+    <env name="DB_DATABASE" value=":memory:"/>
+    <env name="MAIL_MAILER" value="array"/>
+    <env name="QUEUE_CONNECTION" value="sync"/>
+    <env name="SESSION_DRIVER" value="array"/>
+    <env name="TELESCOPE_ENABLED" value="false"/>
+  </php>
+  <source>
+    <include>
+      <directory suffix=".php">./app/Exceptions</directory>
+      <directory suffix=".php">./app/Gates</directory>
+      <directory suffix=".php">./app/Helpers</directory>
+      <directory suffix=".php">./app/Http/Controllers</directory>
+      <directory suffix=".php">./app/Http/Requests</directory>
+      <directory suffix=".php">./app/Imports</directory>
+      <directory suffix=".php">./app/ModelFilters</directory>
+      <directory suffix=".php">./app/Models</directory>
+      <directory suffix=".php">./app/Notifications</directory>
+      <directory suffix=".php">./app/Observers</directory>
+      <directory suffix=".php">./app/Services</directory>
+    </include>
+  </source>
 </phpunit>

--- a/phpunit.xml.bak
+++ b/phpunit.xml.bak
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+    bootstrap="vendor/autoload.php" colors="true">
+    <testsuites>
+        <testsuite name="Unit">
+            <directory suffix="Test.php">./tests/Unit</directory>
+        </testsuite>
+        <testsuite name="Feature">
+            <directory suffix="Test.php">./tests/Feature</directory>
+        </testsuite>
+    </testsuites>
+    <coverage>
+        <include>
+            <directory suffix=".php">./app/Exceptions</directory>
+            <directory suffix=".php">./app/Gates</directory>
+            <directory suffix=".php">./app/Helpers</directory>
+            <directory suffix=".php">./app/Http/Controllers</directory>
+            <directory suffix=".php">./app/Http/Requests</directory>
+            <directory suffix=".php">./app/Imports</directory>
+            <directory suffix=".php">./app/ModelFilters</directory>
+            <directory suffix=".php">./app/Models</directory>
+            <directory suffix=".php">./app/Notifications</directory>
+            <directory suffix=".php">./app/Observers</directory>
+            <directory suffix=".php">./app/Services</directory>
+        </include>
+    </coverage>
+    <php>
+        <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:spsVoiyikpM+oNpeEI6VWZUIZqoCQFEH+DoxEYCiUew="/>
+        <env name="BCRYPT_ROUNDS" value="4"/>
+        <env name="CACHE_DRIVER" value="array"/>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
+        <env name="MAIL_MAILER" value="array"/>
+        <env name="QUEUE_CONNECTION" value="sync"/>
+        <env name="SESSION_DRIVER" value="array"/>
+        <env name="TELESCOPE_ENABLED" value="false"/>
+    </php>
+</phpunit>

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,19 +7,19 @@ import laravel from 'laravel-vite-plugin';
 
 export default defineConfig({
     plugins: [
-        laravel([
-            // 'resources/css/app.css',
-            'resources/js/app.js',
-            'resources/scss/app.scss',
-            'resources/js/enable_searchable_select.ts',
-            'resources/js/enable_tooltip.ts',
-            'resources/js/enable_popover.ts',
-            'resources/js/enable_inputmask.ts',
-            'resources/js/enable_custom_inputmask.ts'
-        ],
-            {
-                refresh: true,
-            }),
+        laravel({
+            input: [
+                // 'resources/css/app.css',
+                'resources/js/app.js',
+                'resources/scss/app.scss',
+                'resources/js/enable_searchable_select.ts',
+                'resources/js/enable_tooltip.ts',
+                'resources/js/enable_popover.ts',
+                'resources/js/enable_inputmask.ts',
+                'resources/js/enable_custom_inputmask.ts'
+            ],
+            refresh: true,
+        }),
 
         checker({
             typescript: true,

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,11 +1,38 @@
 import { defineConfig } from 'vite';
+import { checker } from 'vite-plugin-checker';
+
 import laravel from 'laravel-vite-plugin';
+// import react from '@vitejs/plugin-react';
+// import vue from '@vitejs/plugin-vue';
 
 export default defineConfig({
     plugins: [
-        laravel({
-            input: ['resources/css/app.css', 'resources/js/app.js'],
-            refresh: true,
+        laravel([
+            // 'resources/css/app.css',
+            'resources/js/app.js',
+            'resources/scss/app.scss',
+            'resources/js/enable_searchable_select.ts',
+            'resources/js/enable_tooltip.ts',
+            'resources/js/enable_popover.ts',
+            'resources/js/enable_inputmask.ts',
+            'resources/js/enable_custom_inputmask.ts'
+        ],
+            {
+                refresh: true,
+            }),
+
+        checker({
+            typescript: true,
+            overlay: true,
         }),
+        // react(),
+        // vue({
+        //     template: {
+        //         transformAssetUrls: {
+        //             base: null,
+        //             includeAbsolute: false,
+        //         },
+        //     },
+        // }),
     ],
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,38 +1,11 @@
 import { defineConfig } from 'vite';
-import { checker } from 'vite-plugin-checker';
-
 import laravel from 'laravel-vite-plugin';
-// import react from '@vitejs/plugin-react';
-// import vue from '@vitejs/plugin-vue';
 
 export default defineConfig({
     plugins: [
-        laravel([
-            // 'resources/css/app.css',
-            'resources/js/app.js',
-            'resources/scss/app.scss',
-            'resources/js/enable_searchable_select.ts',
-            'resources/js/enable_tooltip.ts',
-            'resources/js/enable_popover.ts',
-            'resources/js/enable_inputmask.ts',
-            'resources/js/enable_custom_inputmask.ts'
-        ],
-            {
-                refresh: true,
-            }),
-
-        checker({
-            typescript: true,
-            overlay: true,
+        laravel({
+            input: ['resources/css/app.css', 'resources/js/app.js'],
+            refresh: true,
         }),
-        // react(),
-        // vue({
-        //     template: {
-        //         transformAssetUrls: {
-        //             base: null,
-        //             includeAbsolute: false,
-        //         },
-        //     },
-        // }),
     ],
 });


### PR DESCRIPTION
This pull request includes changes for migrating from Laravel Mix to Vite outlined in [Migration Guide](https://github.com/laravel/vite-plugin/blob/main/UPGRADE.md#migrating-from-laravel-mix-to-vite) and automated by the [Vite Converter](https://laravelshift.com/convert-laravel-mix-to-vite).

**Before merging**, you need to:

- Checkout the `shift-97385` branch
- Run `composer update`
- Run `npm install`
- Review **all** comments for additional changes 
- Thoroughly test your application ([no tests?](https://laravelshift.com/laravel-test-generator), [no CI?](https://laravelshift.com/ci-generator))

Please send your feedback to shift@laravelshift.com or share the good vibes on [Twitter](https://twitter.com/laravelshift).
